### PR TITLE
Update deployment.yaml

### DIFF
--- a/charts/commercebackend/Chart.yaml
+++ b/charts/commercebackend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/commercebackend/templates/deployment.yaml
+++ b/charts/commercebackend/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
           command:
             - "bash"
             - "-c"
-            - "python manage.py ensure_adminuser && python manage.py collectstatic"
+            - "python manage.py ensure_adminuser --noinput && python manage.py collectstatic --noinput"
           envFrom:
             - secretRef:
                 name: {{ include "commercebackend.fullname" . }}

--- a/charts/scoretrak/Chart.yaml
+++ b/charts/scoretrak/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 dependencies:
   - name: envoy
@@ -32,7 +32,7 @@ dependencies:
     repository: "file://../payments"
     condition: bank.enabled
   - name: commercebackend
-    version: "0.1.11"
+    version: "0.1.12"
     repository: "file://../commercebackend"
     condition: bank.enabled
   - name: commerceui


### PR DESCRIPTION
fixes prompt:
```
System check identified some issues:

WARNINGS:
bank.Account: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the BankConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
bank.Transaction: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the BankConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
shop.Answer: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the ShopConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
shop.Order: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the ShopConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
shop.Product: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the ShopConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
shop.Question: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the ShopConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
users.User: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the UsersConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
Traceback (most recent call last):
  File "manage.py", line 22, in <module>

You have requested to collect static files at the destination
location as specified in your settings:

    /opt/app/static

This will overwrite existing files!
Are you sure you want to do this?

    main()
  File "manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/opt/app/.venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/opt/app/.venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/app/.venv/lib/python3.8/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/app/.venv/lib/python3.8/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/opt/app/.venv/lib/python3.8/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 184, in handle
    if input(''.join(message)) != 'yes':
EOFError: EOF when reading a line
Type 'yes' to continue, or 'no' to cancel: 
```